### PR TITLE
Update poniard_of_ghastly_retribution.md

### DIFF
--- a/docs/items/weapons/daggers/ar/poniard_of_ghastly_retribution.md
+++ b/docs/items/weapons/daggers/ar/poniard_of_ghastly_retribution.md
@@ -22,15 +22,17 @@ Shots: 1
 
 Rate of Fire: 100%
 
-Range: 5.2
+Range: 5.6
 
-Fame Bonus: 15%
+Shots hit multiple targets
+
+**Merganus' Wish. You have a 4% chance on-hit to summon Merganus' Poniards, which orbits enemies and deals 750 damage per shot, attacking every 0.2s and lasting 2.4s.**
 
 **Drops from Merganus, the Fallen Titan of the Fallen Light raid**
 
 ## Projectile
 
-![Pogger Projectile](https://cdn.discordapp.com/attachments/1160376179996496013/1170816788670459955/normal_poniard.gif)
+![Pogger Projectile](https://github.com/Terracidal/Gifs/blob/7bd38b74784bcc828166902dd9ee607773b5ab48/9f6b9u.gif)
 
   </TabItem>
   <TabItem value="Air" label="Air">
@@ -41,27 +43,29 @@ Fame Bonus: 15%
 
 <i>Forged in the tears of enemies on a full moon.</i>
 
-**Air Rune: Grants 10% chance to dodge incoming projectiles and 8 speed**
+**Air Rune: Grants 10% dodge change and gain 8 speed. Sacrifice damage for a hefty increase in attack speed.**
 
-Damage: 410-430
+Damage: 410-430 (-155/-265)
 
 Shots: 1
 
-Rate of Fire: 150%
+Rate of Fire: 150%(+50%)
 
-Range: 5.2
+Range: 5.6
 
 Shots hit multiple targets
 
     +15 Speed
 
-Fame Bonus: 15%
+**Merganus' Wish - Freedom: You have a 4% chance on-hit to summon Merganus' Poniards, which orbits enemies and deals 500 damage per shot, attacking twice every 0.2s and lasting 2.6s.**
+
+
 
 **Enchanted Poniard of Ghastly Retribution with Ancient Air Rune**
 
 ## Projectile
 
-![PoggerA Projectile](https://cdn.discordapp.com/attachments/1160376179996496013/1170816821813858364/poniard_air.gif)
+![PoggerA Projectile](https://github.com/Terracidal/Gifs/blob/527b8799cf46cea1b7076efdea8e0c020e1d8ed6/9f6cmd.gif)
 
   </TabItem>
   <TabItem value="Earth" label="Earth">
@@ -74,23 +78,24 @@ Fame Bonus: 15%
 
 **Earth Rune: Heavily increases damage but sacrifice rate of fire and piercing. Shots now ignore defense.**
 
-Damage: 800-800
+Damage: 800-800(+235/+105)
 
 Shots: 1
 
 Rate of Fire: 80%
 
-Range: 5.2
+Range: 5.6
 
 Ignores defense of target
 
-Fame Bonus: 15%
+**Merganus' Wish - Strenght: You have a 4% chance on-hit to summon Merganus' Poniards, which orbits enemies and deals 1500 armor piercing damage per shot, attacking every 0.4s and lasting 2.8s.**
+
 
 **Enchanted Poniard of Ghastly Retribution with Ancient Earth Rune**
 
 ## Projectile
 
-![PoggerE Projectile](https://cdn.discordapp.com/attachments/1160376179996496013/1170816811466502184/poniard_earth.gif?)
+![PoggerE Projectile](https://github.com/Terracidal/Gifs/blob/8e663f0f018760c9965ad363b9058c49e7c71533/9f6d4b.gif)
 
 
   </TabItem>
@@ -102,25 +107,28 @@ Fame Bonus: 15%
 
 <i>Forged in the tears of enemies on a full moon.</i>
 
-**Fire Rune: Deal more damage faster, but at a shorter range.**
+**Fire Rune: Deal more damage faster, but at a shorter range, and gain 15 MIght.**
 
-Damage: 445-785
+Damage: 445-785(-120/+90)
 
 Shots: 1
 
-Rate of Fire: 110%
+Rate of Fire: 110% (+10%)
 
-Range: 4.8
+Range: 5.2(-0.4)
 
 Shots hit multiple targets
 
-Fame Bonus: 15%
+    +15 Might
+
+**Merganus' Wish - Revenge: You have a 4% chance on-hit to summon Merganus' Poniards, which orbits enemies and deals 1000 damage per shot, attacking every 0.2s and lasting 2.4s.**
+
 
 **Enchanted Poniard of Ghastly Retribution with Ancient Fire Rune**
 
 ## Projectile
 
-![PoggerF Projectile](https://cdn.discordapp.com/attachments/1160376179996496013/1170816801349849219/poniard_fire.gif)
+![PoggerF Projectile](https://github.com/Terracidal/Gifs/blob/86ddb8e7ee768b34f306f7c90bf58de170105464/9f6dkl.gif)
 
   </TabItem>
   <TabItem value="Water" label="Water">
@@ -133,13 +141,13 @@ Fame Bonus: 15%
 
 **Water Rune: Increases range and adds a second projectile. Shots now ignore defense. Gain wisdom and mana leech.**
 
-Damage: 282-347
+Damage: 282-347 (-283/ -348)
 
 Shots: 2
 
 Rate of Fire: 100%
 
-Range: 5.9
+Range: 6.3 (+0.7)
 
 Ignores defense of target
 
@@ -147,13 +155,14 @@ Ignores defense of target
 
     +1 Mana Leech
     
-Fame Bonus: 15%
+**Merganus' Wish - Knowledge: You have a 4% chance on-hit to summon Merganus' Poniards, which orbits enemies and deals 750 damage per shot, attacking every 0.4s and lasting 2.8s.**
+
 
 **Enchanted Poniard of Ghastly Retribution with Ancient Water Rune**
 
 ## Projectile
 
-![PoggerW Projectile](https://cdn.discordapp.com/attachments/1160376179996496013/1170816858283319336/poniard_water.gif)
+![PoggerW Projectile](https://github.com/Terracidal/Gifs/blob/dbc887491aed5b3f9516f86e486af3ecc97f8e63/9f6e0r.gif)
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Item card states adding an air rune will give 8 speed but in reality is 15. Conflicting info 